### PR TITLE
Add Jekyll semester journey, course schedule, and site polish

### DIFF
--- a/.cursor/skills/promote-semester-post-draft/SKILL.md
+++ b/.cursor/skills/promote-semester-post-draft/SKILL.md
@@ -50,7 +50,8 @@ Semester schedule (see `README.md`):
 6. **Apply edits**
    - Update front matter: `layout: semester`, `title`, `date`, `semester_post`, `semester`, `semester_start`, `semester_end`.
    - Do **not** add `{% include semester-period.html %}` to the body; the semester layout renders term dates and navigation.
-   - Add `image: /assets/images/reports/<term>.png` when the grade report PNG exists (for `jekyll-seo-tag` social previews).
+   - Add `image: /assets/images/reports/<term>.png` when the grade report image exists (for `jekyll-seo-tag` social previews).
+   - Add `description:` (one line) and `tags: [msds, semester-recap]`.
    - Expect `## Transcript` with a markdown list (one `- ` item per course). Each item must include: `The verified learning credential can be found [here](https://...)` with a real URL (not a placeholder), plus the grade report image.
    - **Rename** the file from the draft name to `_posts/YYYY-MM-DD-<slug>.md` (move/rename in the filesystem or editor; do not leave two copies unless the user asks).
 

--- a/.cursor/skills/promote-semester-post-draft/SKILL.md
+++ b/.cursor/skills/promote-semester-post-draft/SKILL.md
@@ -29,6 +29,7 @@ Semester schedule (see `README.md`):
 1. **Read the draft** (path from the user, or default `_posts/semester-post-template.md`). Parse YAML front matter and body.
 
 2. **Set semester metadata** — pick the row from the schedule that matches the draft’s academic term:
+   - `layout: semester`
    - `semester_post: true`
    - `semester`, `title`, `semester_start`, and `semester_end` must match the schedule row for that semester.
    - `date:` must equal `semester_end` (last day of the term’s final month).
@@ -47,8 +48,9 @@ Semester schedule (see `README.md`):
    - Avoid generic slugs like `semester-post` when the content implies something more specific.
 
 6. **Apply edits**
-   - Update front matter: `title`, `date`, `semester_post`, `semester`, `semester_start`, `semester_end`.
-   - Keep `{% include semester-period.html %}` at the top of the body (after front matter).
+   - Update front matter: `layout: semester`, `title`, `date`, `semester_post`, `semester`, `semester_start`, `semester_end`.
+   - Do **not** add `{% include semester-period.html %}` to the body; the semester layout renders term dates and navigation.
+   - Add `image: /assets/images/reports/<term>.png` when the grade report PNG exists (for `jekyll-seo-tag` social previews).
    - Expect `## Transcript` with a markdown list (one `- ` item per course). Each item must include: `The verified learning credential can be found [here](https://...)` with a real URL (not a placeholder), plus the grade report image.
    - **Rename** the file from the draft name to `_posts/YYYY-MM-DD-<slug>.md` (move/rename in the filesystem or editor; do not leave two copies unless the user asks).
 
@@ -95,7 +97,7 @@ Run this **only** after the preview (step 8) has been approved—post file final
 
 - [ ] `semester`, `title`, `semester_start`, and `semester_end` match the semester schedule for this post.
 - [ ] `## Transcript` includes the verified learning credential link line with a real URL.
-- [ ] `semester_post: true` and `{% include semester-period.html %}` present.
+- [ ] `layout: semester` and `semester_post: true` in front matter (no `semester-period` include in body).
 - [ ] `date` equals `semester_end` and matches the filename date prefix.
 - [ ] File lives at `_posts/YYYY-MM-DD-<slug>.md` with matching slug.
 - [ ] Pre-commit run via `.venv` and passing.

--- a/404.html
+++ b/404.html
@@ -1,0 +1,12 @@
+---
+title: Page not found
+permalink: /404.html
+---
+
+# Page not found
+
+The page you requested does not exist.
+
+- [Home](/)
+- [Semester journey](/semesters/)
+- [Tags](/tags/)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ UT Austin Blog
 - **Course schedule** — driven by [`_data/courses.yml`](_data/courses.yml); edit that file to update the table on the home page.
 - **SEO** — `jekyll-seo-tag`, `jekyll-sitemap`, and optional per-post `image:` for social previews (grade report images).
 - **Future posts** — `future: true` in `_config.yml` so dated drafts in `_posts/` build before their publish date.
+- **Navigation** — breadcrumbs, reading time, optional TOC (`toc: true`), tags, related posts, and a [tags index](/tags/).
+- **Plugins** — `jekyll-redirect-from`, `jekyll-include-cache`, `jekyll-relative-links`, `jekyll-gist`, `jekyll-avatar` (see `_config.yml`).
 
 ### Local preview (optional)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 UT Austin Blog
 
+## Site features
+
+- **[Journey](/semesters/)** — semester-by-semester archive with prev/next navigation on each recap post.
+- **Course schedule** — driven by [`_data/courses.yml`](_data/courses.yml); edit that file to update the table on the home page.
+- **SEO** — `jekyll-seo-tag`, `jekyll-sitemap`, and optional per-post `image:` for social previews (grade report images).
+- **Future posts** — `future: true` in `_config.yml` so dated drafts in `_posts/` build before their publish date.
+
+### Local preview (optional)
+
+GitHub Pages builds the site on push. To preview locally, install the [github-pages gem](https://pages.github.com/versions/) and run `bundle exec jekyll serve` from the repository root.
+
 ## Python tooling setup
 
 This repository uses `pre-commit` for text and Markdown quality checks.

--- a/_config.yml
+++ b/_config.yml
@@ -20,10 +20,18 @@ kramdown:
 permalink: pretty
 future: true
 show_excerpts: true
+excerpt_separator: "<!--more-->"
+header_pages:
+  - semesters.md
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
   - jekyll-sitemap
+  - jekyll-redirect-from
+  - jekyll-include-cache
+  - jekyll-relative-links
+  - jekyll-gist
+  - jekyll-avatar
 defaults:
   - scope:
       path: ""

--- a/_config.yml
+++ b/_config.yml
@@ -16,10 +16,20 @@ baseurl: ""
 markdown: kramdown
 kramdown:
   input: GFM
+  auto_ids: true
 permalink: pretty
+future: true
+show_excerpts: true
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-sitemap
+defaults:
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: "post"
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_data/courses.yml
+++ b/_data/courses.yml
@@ -1,0 +1,75 @@
+- code: DSC 395T
+  name: Data Structures and Algorithms
+  semester: Fall 2023
+  grade: B+
+  taken: true
+- code: DSC 381
+  name: Probability and Simulation Based Inference
+  semester: Fall 2023
+  grade: B+
+  taken: true
+- code: DSC 382
+  name: Foundations of Regression and Predictive Modeling
+  semester: Spring 2024
+  grade: A
+  taken: true
+- code: DSC 385
+  name: Data Exploration and Visualization
+  semester: Spring 2024
+  grade: A
+  taken: true
+- code: DSC 391L
+  name: Principles of Machine Learning
+  semester: Fall 2024
+  grade: A-
+  taken: true
+- code: DSC 394D
+  name: Deep Learning
+  semester: Spring 2025
+  grade: A
+  taken: true
+- code: DSC 395T
+  name: Reinforcement Learning
+  semester: Summer 2025
+  grade: A
+  taken: true
+- code: DSC 383
+  name: Advanced Predictive Models for Complex Data
+  semester: Summer 2025
+  grade: A
+  taken: true
+- code: DSC 395T
+  name: Advances in Deep Generative Models
+  semester: Fall 2025
+  grade: A
+  taken: true
+- code: DSC 395T
+  name: Principles of Data Science
+  semester: Spring 2026
+  grade: A
+  taken: true
+- code: DSC 384
+  name: Design Principles and Causal Inference
+  semester: null
+  grade: null
+  taken: false
+- code: DSC 387
+  name: Data Science for Health Discovery and Innovation
+  semester: null
+  grade: null
+  taken: false
+- code: DSC 388
+  name: Natural Language Processing
+  semester: null
+  grade: null
+  taken: false
+- code: DSC 388J
+  name: Optimization
+  semester: null
+  grade: null
+  taken: false
+- code: DSC 395T
+  name: Advances in Deep Learning
+  semester: null
+  grade: null
+  taken: false

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,0 +1,12 @@
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="{{ '/' | relative_url }}">Home</a>
+  {% if page.semester_post %}
+  <span aria-hidden="true"> / </span>
+  <a href="{{ '/semesters/' | relative_url }}">Journey</a>
+  <span aria-hidden="true"> / </span>
+  <span>Semester {{ page.semester }}</span>
+  {% elsif page.title %}
+  <span aria-hidden="true"> / </span>
+  <span>{{ page.title | escape }}</span>
+  {% endif %}
+</nav>

--- a/_includes/course-schedule.html
+++ b/_includes/course-schedule.html
@@ -1,0 +1,5 @@
+| Course | Course name | Semester | Grade |
+|--------|-------------|----------|-------|
+{% for course in site.data.courses %}
+| {{ course.code }} | {{ course.name }} | {% if course.taken %}{{ course.semester }}{% else %}—{% endif %} | {% if course.taken %}{{ course.grade }}{% else %}—{% endif %} |
+{% endfor %}

--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -1,0 +1,3 @@
+{% if page.date and page.title %}
+{% include json-ld-article.html %}
+{% endif %}

--- a/_includes/json-ld-article.html
+++ b/_includes/json-ld-article.html
@@ -1,0 +1,19 @@
+{% if page.date and page.title %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": {{ page.title | jsonify }},
+  "datePublished": "{{ page.date | date_to_xmlschema }}",
+  "author": {
+    "@type": "Person",
+    "name": {{ site.author | default: site.title | jsonify }}
+  },
+  "description": {{ page.description | default: page.excerpt | strip_html | strip_newlines | truncate: 160 | jsonify }},
+  "url": "{{ page.url | absolute_url }}"
+  {% if page.image %},
+  "image": "{{ page.image | absolute_url }}"
+  {% endif %}
+}
+</script>
+{% endif %}

--- a/_includes/reading-time.html
+++ b/_includes/reading-time.html
@@ -1,0 +1,4 @@
+{% assign words = include.content | default: content | number_of_words %}
+{% if words > 0 %}
+<span class="reading-time"> · {{ words | divided_by: 200 | plus: 1 }} min read</span>
+{% endif %}

--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -1,0 +1,24 @@
+{% if page.tags and page.tags.size > 0 %}
+{% assign related_count = 0 %}
+{% assign related_limit = 3 %}
+<section class="related-posts">
+  <h2>Related posts</h2>
+  <ul>
+    {% for post in site.posts %}
+      {% unless post.url == page.url %}
+        {% assign shared = false %}
+        {% for tag in page.tags %}
+          {% if post.tags contains tag %}
+            {% assign shared = true %}
+            {% break %}
+          {% endif %}
+        {% endfor %}
+        {% if shared and related_count < related_limit %}
+          {% assign related_count = related_count | plus: 1 %}
+          <li><a href="{{ post.url | relative_url }}">{{ post.title | escape }}</a></li>
+        {% endif %}
+      {% endunless %}
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}

--- a/_includes/semester-dates.html
+++ b/_includes/semester-dates.html
@@ -1,0 +1,8 @@
+{% assign sem = include.post | default: page %}
+{% assign start_month = sem.semester_start | date: "%-m" %}
+{% if start_month == "9" %}Sept{% else %}{{ sem.semester_start | date: "%b" }}{% endif %}
+{{ sem.semester_start | date: "%Y" }}
+–
+{% assign end_month = sem.semester_end | date: "%-m" %}
+{% if end_month == "9" %}Sept{% else %}{{ sem.semester_end | date: "%b" }}{% endif %}
+{{ sem.semester_end | date: "%Y" }}

--- a/_includes/semester-nav.html
+++ b/_includes/semester-nav.html
@@ -1,0 +1,25 @@
+{% if page.semester_post %}
+{% assign semester_posts = site.posts | where_exp: "item", "item.semester_post" | sort: "semester" %}
+{% assign prev_semester = page.semester | minus: 1 %}
+{% assign next_semester = page.semester | plus: 1 %}
+{% assign prev_post = nil %}
+{% assign next_post = nil %}
+{% for item in semester_posts %}
+  {% if item.semester == prev_semester %}
+    {% assign prev_post = item %}
+  {% endif %}
+  {% if item.semester == next_semester %}
+    {% assign next_post = item %}
+  {% endif %}
+{% endfor %}
+{% if prev_post or next_post %}
+<nav class="semester-nav" aria-label="Semester navigation">
+  {% if prev_post %}
+  <a class="semester-nav-prev" href="{{ prev_post.url | relative_url }}">&larr; Semester {{ prev_post.semester }}: {{ prev_post.title }}</a>
+  {% endif %}
+  {% if next_post %}
+  <a class="semester-nav-next" href="{{ next_post.url | relative_url }}">Semester {{ next_post.semester }}: {{ next_post.title }} &rarr;</a>
+  {% endif %}
+</nav>
+{% endif %}
+{% endif %}

--- a/_includes/semester-period.html
+++ b/_includes/semester-period.html
@@ -2,12 +2,6 @@
 <p class="post-semester-meta">
   <strong>Semester {{ page.semester }}</strong>
   ·
-  {% assign start_month = page.semester_start | date: "%-m" %}
-  {% if start_month == "9" %}Sept{% else %}{{ page.semester_start | date: "%b" }}{% endif %}
-  {{ page.semester_start | date: "%Y" }}
-  –
-  {% assign end_month = page.semester_end | date: "%-m" %}
-  {% if end_month == "9" %}Sept{% else %}{{ page.semester_end | date: "%b" }}{% endif %}
-  {{ page.semester_end | date: "%Y" }}
+  {% include semester-dates.html %}
 </p>
 {% endif %}

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,0 +1,16 @@
+{% if page.toc %}
+<nav class="post-toc" aria-label="Table of contents">
+  <p class="post-toc-title"><strong>On this page</strong></p>
+  <ul>
+    {% assign sections = content | split: '<h2 id="' %}
+    {% for section in sections offset: 1 %}
+      {% assign id = section | split: '"' | first %}
+      {% assign heading_html = section | split: '</h2>' | first %}
+      {% assign heading_text = heading_html | split: '>' | last | strip_html | strip %}
+      {% if heading_text != "" %}
+      <li><a href="#{{ id }}">{{ heading_text }}</a></li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+</nav>
+{% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,37 @@
+---
+layout: default
+---
+<div class="home">
+  {%- if page.title -%}
+    <h1 class="page-heading">{{ page.title }}</h1>
+  {%- endif -%}
+
+  {{ content }}
+
+  {%- if site.posts.size > 0 -%}
+    <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
+    <ul class="post-list">
+      {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+      {%- for post in site.posts -%}
+      <li class="post-item{% if post.semester_post %} semester-card{% endif %}">
+        {%- if post.semester_post -%}
+        <p class="badge">Semester {{ post.semester }} · {% include semester-dates.html post=post %}</p>
+        {%- if post.image -%}
+        <a href="{{ post.url | relative_url }}"><img class="semester-card-thumb" src="{{ post.image | relative_url }}" alt="" width="120" loading="lazy"></a>
+        {%- endif -%}
+        {%- else -%}
+        <span class="post-meta">{{ post.date | date: date_format }}</span>
+        {%- endif -%}
+        <h3>
+          <a class="post-link" href="{{ post.url | relative_url }}">
+            {{ post.title | escape }}
+          </a>
+        </h3>
+        {%- if site.show_excerpts -%}
+          <div class="post-excerpt">{{ post.excerpt }}</div>
+        {%- endif -%}
+      </li>
+      {%- endfor -%}
+    </ul>
+  {%- endif -%}
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,33 @@
+---
+layout: default
+---
+<article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
+
+  {% include breadcrumbs.html %}
+
+  <header class="post-header">
+    <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
+    <p class="post-meta">
+      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+        {{ page.date | date: date_format }}
+      </time>
+      {%- include reading-time.html content=content -%}
+      {%- if page.tags and page.tags.size > 0 -%}
+        ·
+        {%- for tag in page.tags -%}
+          <a href="{{ '/tags/' | relative_url }}#tag-{{ tag | slugify }}">{{ tag }}</a>{%- unless forloop.last -%}, {%- endunless -%}
+        {%- endfor -%}
+      {%- endif -%}
+    </p>
+  </header>
+
+  {% include toc.html %}
+
+  <div class="post-content e-content" itemprop="articleBody">
+    {{ content }}
+  </div>
+
+  {% include related-posts.html %}
+
+</article>

--- a/_layouts/semester.html
+++ b/_layouts/semester.html
@@ -1,0 +1,6 @@
+---
+layout: post
+---
+{% include semester-period.html %}
+{{ content }}
+{% include semester-nav.html %}

--- a/_layouts/semester.html
+++ b/_layouts/semester.html
@@ -3,4 +3,4 @@ layout: post
 ---
 {% include semester-period.html %}
 {{ content }}
-{% include semester-nav.html %}
+{% include_cached semester-nav.html, page.semester %}

--- a/_posts/2023-05-23-admission.md
+++ b/_posts/2023-05-23-admission.md
@@ -1,6 +1,8 @@
 ---
 title: "Admission"
 date: 2023-05-23
+description: How I decided to apply to the UT Austin MSDS program while working full time.
+tags: [msds, admission]
 ---
 
 I was admitted into the Masters of Data Science program at UT Austin in May 2023. At that point, I had graduated from UBC a year earlier and was working full-time at GE Vernova (General Electric). Although I enjoyed the transition to professional life, I realized I missed gaining knowledge about topics I am interested in and applying it in different applications.

--- a/_posts/2023-12-31-first-semester.md
+++ b/_posts/2023-12-31-first-semester.md
@@ -7,6 +7,8 @@ semester: 1
 semester_start: 2023-09-01
 semester_end: 2023-12-31
 image: /assets/images/reports/fall-2023.png
+description: Fall 2023 recap — DSA and probability while balancing full-time work.
+tags: [msds, semester-recap]
 ---
 
 It's September 2023 and I just moved to Burnaby from Kelowna - a fresh new start. The summer was very hectic and I was just getting my bearings after packing up the old apartment, moving into a new apartment, and helping family. I now had to balance the 2 courses that I registered for with full time work.

--- a/_posts/2023-12-31-first-semester.md
+++ b/_posts/2023-12-31-first-semester.md
@@ -1,13 +1,13 @@
 ---
 title: "First Semester"
 date: 2023-12-31
+layout: semester
 semester_post: true
 semester: 1
 semester_start: 2023-09-01
 semester_end: 2023-12-31
+image: /assets/images/reports/fall-2023.png
 ---
-
-{% include semester-period.html %}
 
 It's September 2023 and I just moved to Burnaby from Kelowna - a fresh new start. The summer was very hectic and I was just getting my bearings after packing up the old apartment, moving into a new apartment, and helping family. I now had to balance the 2 courses that I registered for with full time work.
 

--- a/_posts/2024-04-30-bounce-back.md
+++ b/_posts/2024-04-30-bounce-back.md
@@ -1,13 +1,13 @@
 ---
 title: "Bounce Back"
 date: 2024-04-30
+layout: semester
 semester_post: true
 semester: 2
 semester_start: 2024-01-01
 semester_end: 2024-04-30
+image: /assets/images/reports/spring-2024.png
 ---
-
-{% include semester-period.html %}
 
 After being humbled by the first semester, I realized I needed to ease off a bit with the courses. I had taken Data Structures and Algorithms and Probability and Simulation Based Inference because I had a background in these from my undergrad, but the Master's workload has been kinda brutal. So I studied the courses on [the Hub](https://msdshub.com/), which is an excellent resource during course planning, to try to figure out what the most amount of time I'm willing to spend outside of work. I tend to hit the `Scale of 1-10` button because it feels a bit more natural to me to gauge difficulty using that compared to `Scale of 1-5` or `Scale of 1-7`, sort on Workload, and eventually using that + the Program of Work, I decided on my next 2 oppressors, Foundations of Regression and Predictive Modelling  and Data Exploration and Visualization.
 

--- a/_posts/2024-04-30-bounce-back.md
+++ b/_posts/2024-04-30-bounce-back.md
@@ -7,6 +7,8 @@ semester: 2
 semester_start: 2024-01-01
 semester_end: 2024-04-30
 image: /assets/images/reports/spring-2024.png
+description: Spring 2024 recap — regression and visualization from Dubai.
+tags: [msds, semester-recap]
 ---
 
 After being humbled by the first semester, I realized I needed to ease off a bit with the courses. I had taken Data Structures and Algorithms and Probability and Simulation Based Inference because I had a background in these from my undergrad, but the Master's workload has been kinda brutal. So I studied the courses on [the Hub](https://msdshub.com/), which is an excellent resource during course planning, to try to figure out what the most amount of time I'm willing to spend outside of work. I tend to hit the `Scale of 1-10` button because it feels a bit more natural to me to gauge difficulty using that compared to `Scale of 1-5` or `Scale of 1-7`, sort on Workload, and eventually using that + the Program of Work, I decided on my next 2 oppressors, Foundations of Regression and Predictive Modelling  and Data Exploration and Visualization.

--- a/_posts/2026-04-30-last-semester.md
+++ b/_posts/2026-04-30-last-semester.md
@@ -6,6 +6,8 @@ semester_post: true
 semester: 8
 semester_start: 2026-01-01
 semester_end: 2026-04-30
+description: Final spring 2026 semester and wrapping up the MSDS degree.
+tags: [msds, semester-recap]
 ---
 
 I'm writing this blog post shortly after I completed my last assignment in my last ever course DSC 385: Principles of Data Science. Its funny how I'm taking a "principles" class at the end of my degree after I completed all the hard courses. To be honest, if it were up to me, I wouldn't have taken this class, I would've taken either the Optimization class or the Advances in Deep Learning class, I only took it because it was a graduation requirement.

--- a/_posts/2026-04-30-last-semester.md
+++ b/_posts/2026-04-30-last-semester.md
@@ -1,13 +1,12 @@
 ---
 title: "Last But Not Least"
 date: 2026-04-30
+layout: semester
 semester_post: true
 semester: 8
 semester_start: 2026-01-01
 semester_end: 2026-04-30
 ---
-
-{% include semester-period.html %}
 
 I'm writing this blog post shortly after I completed my last assignment in my last ever course DSC 385: Principles of Data Science. Its funny how I'm taking a "principles" class at the end of my degree after I completed all the hard courses. To be honest, if it were up to me, I wouldn't have taken this class, I would've taken either the Optimization class or the Advances in Deep Learning class, I only took it because it was a graduation requirement.
 

--- a/_posts/2026-05-04-tips-and-tricks.md
+++ b/_posts/2026-05-04-tips-and-tricks.md
@@ -1,6 +1,9 @@
 ---
 title: "Tips and Tricks"
 date: 2026-05-04
+description: Practical advice for MSDS students juggling work, school, and life.
+tags: [msds, tips]
+toc: true
 ---
 
 Now that the degree is behind me, I wanted to take a step back and write down the tips and tricks that helped me streamline my work and get through the program while juggling full-time work and life. Some of these I figured out early on, others took a few semesters of trial and error. Hopefully a future student finds something here useful.

--- a/_templates/semester-post-template.md
+++ b/_templates/semester-post-template.md
@@ -1,16 +1,16 @@
 ---
 title: "Semester Title"
 date: YYYY-MM-DD
+layout: semester
 semester_post: true
 semester: 0
 semester_start: YYYY-MM-DD
 semester_end: YYYY-MM-DD
 ---
 
-{% include semester-period.html %}
-
 Set `semester`, `title`, `semester_start`, and `semester_end` from the semester schedule in the promote skill.
 Set `date` to `semester_end` and use the same date in the filename: `_posts/YYYY-MM-DD-<slug>.md`.
+Add `image: /assets/images/reports/<term>.png` when the grade report image is ready.
 
 ## Context
 

--- a/_templates/semester-post-template.md
+++ b/_templates/semester-post-template.md
@@ -6,6 +6,8 @@ semester_post: true
 semester: 0
 semester_start: YYYY-MM-DD
 semester_end: YYYY-MM-DD
+description: Short summary for search and social previews.
+tags: [msds, semester-recap]
 ---
 
 Set `semester`, `title`, `semester_start`, and `semester_end` from the semester schedule in the promote skill.

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -45,3 +45,56 @@
 .post-list .post-item.semester-card {
   margin-bottom: 2rem;
 }
+
+.breadcrumbs {
+  font-size: 0.9rem;
+  color: #666;
+  margin-bottom: 1rem;
+}
+
+.breadcrumbs a {
+  color: #2a7ae2;
+}
+
+.reading-time {
+  color: #666;
+}
+
+.post-toc {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background: #f8f8f8;
+  border-left: 3px solid #e8e8e8;
+}
+
+.post-toc-title {
+  margin: 0 0 0.5rem;
+}
+
+.post-toc ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.related-posts {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e8e8e8;
+}
+
+.related-posts h2 {
+  font-size: 1.25rem;
+}
+
+.tag-list {
+  padding-left: 0;
+  list-style: none;
+}
+
+.tag-list > li {
+  margin-bottom: 2rem;
+}
+
+.page-not-found {
+  text-align: center;
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,47 @@
+---
+---
+
+@import "minima";
+
+.post-semester-meta {
+  margin-bottom: 1rem;
+}
+
+.semester-nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e8e8e8;
+}
+
+.semester-nav-next {
+  margin-left: auto;
+}
+
+.semester-card {
+  margin-bottom: 1.5rem;
+  list-style: none;
+}
+
+.semester-card .badge {
+  font-size: 0.85rem;
+  color: #666;
+  margin-bottom: 0.25rem;
+}
+
+.semester-card-thumb {
+  display: block;
+  margin: 0.5rem 0;
+  border: 1px solid #e8e8e8;
+}
+
+.journey-list {
+  padding-left: 0;
+}
+
+.post-list .post-item.semester-card {
+  margin-bottom: 2rem;
+}

--- a/index.md
+++ b/index.md
@@ -6,24 +6,10 @@ This blog serves as a journal for my journey as a Master's of Data Science stude
 
 I started this way after I completed a big portion of my degree, but I wanted to document my efforts, results, and resources for others to use as reference.
 
+Read the [semester journey](/semesters/) for term-by-term posts.
+
 ## My Course Schedule
 
 All courses in the [MSDS curriculum](https://cdso.utexas.edu/msds). Rows are sorted by the semester I took each course; courses I did not take are listed at the end.
 
-| Course | Course name | Semester | Grade |
-|--------|-------------|----------|-------|
-| DSC 395T | Data Structures and Algorithms | Fall 2023 | B+ |
-| DSC 381 | Probability and Simulation Based Inference | Fall 2023 | B+ |
-| DSC 382 | Foundations of Regression and Predictive Modeling | Spring 2024 | A |
-| DSC 385 | Data Exploration and Visualization | Spring 2024 | A |
-| DSC 391L | Principles of Machine Learning | Fall 2024 | A- |
-| DSC 394D | Deep Learning | Spring 2025 | A |
-| DSC 395T | Reinforcement Learning | Summer 2025 | A |
-| DSC 383 | Advanced Predictive Models for Complex Data | Summer 2025 | A |
-| DSC 395T | Advances in Deep Generative Models | Fall 2025 | A |
-| DSC 395T | Principles of Data Science | Spring 2026 | A |
-| DSC 384 | Design Principles and Causal Inference | — | — |
-| DSC 387 | Data Science for Health Discovery and Innovation | — | — |
-| DSC 388 | Natural Language Processing | — | — |
-| DSC 388J | Optimization | — | — |
-| DSC 395T | Advances in Deep Learning | — | — |
+{% include course-schedule.html %}

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ This blog serves as a journal for my journey as a Master's of Data Science stude
 
 I started this way after I completed a big portion of my degree, but I wanted to document my efforts, results, and resources for others to use as reference.
 
-Read the [semester journey](/semesters/) for term-by-term posts.
+Read the [semester journey](/semesters/) for term-by-term posts, or browse by [tag](/tags/).
 
 ## My Course Schedule
 

--- a/scripts/check_post_structure.py
+++ b/scripts/check_post_structure.py
@@ -109,6 +109,10 @@ def validate_semester_metadata(front_matter: str) -> list[str]:
     if front_matter_value(front_matter, "title") is None:
         errors.append("missing 'title'")
 
+    layout = front_matter_value(front_matter, "layout")
+    if layout != "semester":
+        errors.append("missing or invalid 'layout' (expected 'semester')")
+
     semester_raw = front_matter_value(front_matter, "semester")
     if semester_raw is None:
         errors.append("missing 'semester' (expected 1-8)")

--- a/semesters.md
+++ b/semesters.md
@@ -1,0 +1,25 @@
+---
+title: Journey
+permalink: /semesters/
+---
+
+Semester-by-semester write-ups from my MSDS program. [Back to home](/).
+
+<!-- vale off -->
+{% assign semester_posts = site.posts | where_exp: "item", "item.semester_post" | sort: "semester" %}
+
+<ul class="post-list journey-list">
+{% for post in semester_posts %}
+  <li class="post-item semester-card">
+    <p class="badge">Semester {{ post.semester }} · {% include semester-dates.html post=post %}</p>
+    <h3>
+      <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+    </h3>
+    {% if post.image %}
+    <a href="{{ post.url | relative_url }}"><img class="semester-card-thumb" src="{{ post.image | relative_url }}" alt="" width="120" loading="lazy"></a>
+    {% endif %}
+    <div class="post-excerpt">{{ post.excerpt }}</div>
+  </li>
+{% endfor %}
+</ul>
+<!-- vale on -->

--- a/tags.md
+++ b/tags.md
@@ -1,0 +1,26 @@
+---
+title: Tags
+permalink: /tags/
+---
+
+Posts grouped by topic.
+
+<!-- vale off -->
+{% assign all_tags = site.posts | map: "tags" | flatten | uniq | sort %}
+<ul class="tag-list">
+{% for tag in all_tags %}
+  {% if tag %}
+  <li id="tag-{{ tag | slugify }}">
+    <h2>{{ tag }}</h2>
+    <ul>
+      {% for post in site.posts %}
+        {% if post.tags contains tag %}
+        <li><a href="{{ post.url | relative_url }}">{{ post.title | escape }}</a></li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </li>
+  {% endif %}
+{% endfor %}
+</ul>
+<!-- vale on -->


### PR DESCRIPTION
## Summary

GitHub Pages–compatible Jekyll improvements in two commits:

**Journey and course schedule**
- `jekyll-sitemap`, `future: true`, Kramdown heading anchors, and home page excerpts
- Course schedule driven by `_data/courses.yml` on the home page
- Journey archive at `/semesters/` with semester cards
- `semester` layout with term dates, prev/next navigation, and customized home cards
- Social preview `image:` on semester posts 1 and 2

**Navigation, SEO, and tagging**
- Extra allowed plugins: `jekyll-redirect-from`, `jekyll-include-cache`, `jekyll-relative-links`, `jekyll-gist`, `jekyll-avatar`
- `header_pages` link to Journey in the site header
- Post layout: breadcrumbs, reading time, optional TOC (`toc: true`), tag links, related posts
- JSON-LD (`BlogPosting`) via `custom-head.html`
- Tags index at `/tags/`, tag/description front matter on all posts
- Custom `404.html`
- `check_post_structure.py` requires `layout: semester` on semester posts
- Promote-semester-post skill and README updated

## Test plan

- [ ] Confirm GitHub Pages build succeeds after merge
- [ ] Home page shows semester cards with badges, excerpts, and report thumbnails where `image` is set
- [ ] Header includes a Journey link; `/semesters/` lists semester posts in order
- [ ] Semester posts show term meta and prev/next nav (1 ↔ 2; 8 links back to 2 until more posts exist)
- [ ] Course table on the home page matches `_data/courses.yml`
- [ ] `/sitemap.xml` is generated
- [ ] Posts show breadcrumbs, reading time, and tags; tips post shows TOC
- [ ] `/tags/` lists posts by tag; related posts appear on tagged posts
- [ ] `/404.html` renders with helpful links