### PR TITLE
Fix include_cached syntax for GitHub Pages build

### DIFF
--- a/_includes/semester-nav.html
+++ b/_includes/semester-nav.html
@@ -1,7 +1,8 @@
-{% if page.semester_post %}
+{% assign current_semester = include.semester | default: page.semester %}
+{% if current_semester %}
 {% assign semester_posts = site.posts | where_exp: "item", "item.semester_post" | sort: "semester" %}
-{% assign prev_semester = page.semester | minus: 1 %}
-{% assign next_semester = page.semester | plus: 1 %}
+{% assign prev_semester = current_semester | minus: 1 %}
+{% assign next_semester = current_semester | plus: 1 %}
 {% assign prev_post = nil %}
 {% assign next_post = nil %}
 {% for item in semester_posts %}

--- a/_layouts/semester.html
+++ b/_layouts/semester.html
@@ -3,4 +3,4 @@ layout: post
 ---
 {% include semester-period.html %}
 {{ content }}
-{% include_cached semester-nav.html, page.semester %}
+{% include_cached semester-nav.html semester=page.semester %}


### PR DESCRIPTION
## Summary

Rebased onto `main` after #7 merged. This PR contains a single fix: `jekyll-include-cache` on GitHub Pages requires **named** parameters.

**Before (build failure):**
```liquid
{% include_cached semester-nav.html, page.semester %}
```

**After:**
```liquid
{% include_cached semester-nav.html semester=page.semester %}
```

`semester-nav.html` reads `include.semester` (with fallback to `page.semester`).

## Test plan

- [ ] GitHub Pages Jekyll build succeeds (no `Invalid syntax for include tag` error)
- [ ] Semester posts render prev/next navigation correctly