### PR TITLE
Fix home layout, course table, and archive lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ UT Austin Blog
 
 ## Site features
 
-- **[Journey](/semesters/)** — semester-by-semester archive with prev/next navigation on each recap post.
+- **[By Semester](/semesters/)** — semester recap index with prev/next navigation on each post.
+- **[By Tag](/tags/)** — posts grouped by topic with optional date sort on each tag section.
 - **Course schedule** — driven by [`_data/courses.yml`](_data/courses.yml); edit that file to update the table on the home page.
 - **SEO** — `jekyll-seo-tag`, `jekyll-sitemap`, and optional per-post `image:` for social previews (grade report images).
 - **Future posts** — `future: true` in `_config.yml` so dated drafts in `_posts/` build before their publish date.

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,7 @@ show_excerpts: true
 excerpt_separator: "<!--more-->"
 header_pages:
   - semesters.md
+  - tags.md
 plugins:
   - jekyll-feed
   - jekyll-seo-tag

--- a/_includes/course-schedule.html
+++ b/_includes/course-schedule.html
@@ -1,5 +1,20 @@
-| Course | Course name | Semester | Grade |
-|--------|-------------|----------|-------|
-{% for course in site.data.courses %}
-| {{ course.code }} | {{ course.name }} | {% if course.taken %}{{ course.semester }}{% else %}—{% endif %} | {% if course.taken %}{{ course.grade }}{% else %}—{% endif %} |
-{% endfor %}
+<table class="course-schedule">
+  <thead>
+    <tr>
+      <th scope="col">Course</th>
+      <th scope="col">Course name</th>
+      <th scope="col">Semester</th>
+      <th scope="col">Grade</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for course in site.data.courses %}
+    <tr>
+      <td>{{ course.code }}</td>
+      <td>{{ course.name }}</td>
+      <td>{% if course.taken %}{{ course.semester }}{% else %}—{% endif %}</td>
+      <td>{% if course.taken %}{{ course.grade }}{% else %}—{% endif %}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -1,3 +1,4 @@
 {% if page.date and page.title %}
 {% include json-ld-article.html %}
 {% endif %}
+<script src="{{ '/assets/js/post-list-sort.js' | relative_url }}" defer></script>

--- a/_includes/post-list-item.html
+++ b/_includes/post-list-item.html
@@ -1,0 +1,20 @@
+{%- assign post = include.post -%}
+{%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+<li class="post-item{% if post.semester_post %} semester-card{% endif %}"
+    data-date="{{ post.date | date: '%Y%m%d' }}"
+    {% if post.semester %}data-semester="{{ post.semester }}"{% endif %}>
+  {%- if post.semester_post -%}
+  <p class="badge">Semester {{ post.semester }} · {% include semester-dates.html post=post %}</p>
+  {%- if post.image -%}
+  <a href="{{ post.url | relative_url }}"><img class="semester-card-thumb" src="{{ post.image | relative_url }}" alt="" width="120" loading="lazy"></a>
+  {%- endif -%}
+  {%- else -%}
+  <span class="post-meta">{{ post.date | date: date_format }}</span>
+  {%- endif -%}
+  <h3>
+    <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+  </h3>
+  {%- if post.description -%}
+  <p class="post-teaser">{{ post.description | escape }}</p>
+  {%- endif -%}
+</li>

--- a/_includes/post-list-sort-controls.html
+++ b/_includes/post-list-sort-controls.html
@@ -1,0 +1,9 @@
+<div class="post-list-sort-controls" role="group" aria-label="Sort posts">
+  {%- if include.mode == 'semester' -%}
+  <button type="button" data-sort-key="semester" data-sort-order="asc" class="is-active" aria-pressed="true">By semester</button>
+  <button type="button" data-sort-key="date" data-sort-order="asc" aria-pressed="false">By date</button>
+  {%- else -%}
+  <button type="button" data-sort-key="date" data-sort-order="asc" class="is-active" aria-pressed="true">Oldest first</button>
+  <button type="button" data-sort-key="date" data-sort-order="desc" aria-pressed="false">Newest first</button>
+  {%- endif -%}
+</div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -10,28 +10,14 @@ layout: default
 
   {%- if site.posts.size > 0 -%}
     <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
-    <ul class="post-list">
-      {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-      {%- for post in site.posts -%}
-      <li class="post-item{% if post.semester_post %} semester-card{% endif %}">
-        {%- if post.semester_post -%}
-        <p class="badge">Semester {{ post.semester }} · {% include semester-dates.html post=post %}</p>
-        {%- if post.image -%}
-        <a href="{{ post.url | relative_url }}"><img class="semester-card-thumb" src="{{ post.image | relative_url }}" alt="" width="120" loading="lazy"></a>
-        {%- endif -%}
-        {%- else -%}
-        <span class="post-meta">{{ post.date | date: date_format }}</span>
-        {%- endif -%}
-        <h3>
-          <a class="post-link" href="{{ post.url | relative_url }}">
-            {{ post.title | escape }}
-          </a>
-        </h3>
-        {%- if site.show_excerpts -%}
-          <div class="post-excerpt">{{ post.excerpt }}</div>
-        {%- endif -%}
-      </li>
-      {%- endfor -%}
-    </ul>
+    <div class="post-list-sortable" data-sort-default="asc" data-sort-default-key="date" data-sort-storage-key="/">
+      {% include post-list-sort-controls.html %}
+      <ul class="post-list">
+        {%- assign posts_sorted = site.posts | sort: 'date' -%}
+        {%- for post in posts_sorted -%}
+          {% include post-list-item.html post=post %}
+        {%- endfor -%}
+      </ul>
+    </div>
   {%- endif -%}
 </div>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -98,3 +98,44 @@
 .page-not-found {
   text-align: center;
 }
+
+.course-schedule {
+  width: 100%;
+  margin-bottom: 1.5rem;
+}
+
+.post-teaser {
+  margin: 0.25rem 0 0;
+  color: #666;
+}
+
+.post-list-sort-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.post-list-sort-controls button {
+  font-size: 0.85rem;
+  padding: 0.35rem 0.75rem;
+  border: 1px solid #e8e8e8;
+  background: #fff;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.post-list-sort-controls button.is-active {
+  border-color: #2a7ae2;
+  color: #2a7ae2;
+}
+
+.post-list-sort-controls button:hover {
+  border-color: #2a7ae2;
+}
+
+.tag-post-list .post-item {
+  list-style: none;
+  margin-bottom: 1.25rem;
+}

--- a/assets/js/post-list-sort.js
+++ b/assets/js/post-list-sort.js
@@ -1,0 +1,73 @@
+(function () {
+  const STORAGE_PREFIX = "postSort:";
+
+  function sortList(ul, key, order) {
+    const items = Array.from(ul.querySelectorAll(":scope > li"));
+    const mult = order === "desc" ? -1 : 1;
+    const attr = key === "semester" ? "semester" : "date";
+
+    items.sort((a, b) => {
+      const av = Number(a.dataset[attr] || 0);
+      const bv = Number(b.dataset[attr] || 0);
+      return (av - bv) * mult;
+    });
+
+    items.forEach((li) => ul.appendChild(li));
+  }
+
+  function storageKey(container) {
+    return STORAGE_PREFIX + (container.dataset.sortStorageKey || window.location.pathname);
+  }
+
+  function updateButtons(controls, key, order) {
+    controls.querySelectorAll("button[data-sort-key]").forEach((btn) => {
+      const active =
+        btn.dataset.sortKey === key && btn.dataset.sortOrder === order;
+      btn.classList.toggle("is-active", active);
+      btn.setAttribute("aria-pressed", active ? "true" : "false");
+    });
+  }
+
+  function initContainer(container) {
+    const ul = container.querySelector(".post-list");
+    const controls = container.querySelector(".post-list-sort-controls");
+    if (!ul || !controls) return;
+
+    const defaultKey = container.dataset.sortDefaultKey || "date";
+    const defaultOrder = container.dataset.sortDefault || "asc";
+    let activeKey = defaultKey;
+    let activeOrder = defaultOrder;
+
+    const saved = localStorage.getItem(storageKey(container));
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        activeKey = parsed.key || activeKey;
+        activeOrder = parsed.order || activeOrder;
+      } catch (_) {
+        /* ignore invalid storage */
+      }
+    }
+
+    sortList(ul, activeKey, activeOrder);
+    updateButtons(controls, activeKey, activeOrder);
+
+    controls.addEventListener("click", (event) => {
+      const btn = event.target.closest("button[data-sort-key]");
+      if (!btn) return;
+
+      const sortKey = btn.dataset.sortKey;
+      const sortOrder = btn.dataset.sortOrder;
+      sortList(ul, sortKey, sortOrder);
+      updateButtons(controls, sortKey, sortOrder);
+      localStorage.setItem(
+        storageKey(container),
+        JSON.stringify({ key: sortKey, order: sortOrder })
+      );
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll(".post-list-sortable").forEach(initContainer);
+  });
+})();

--- a/index.md
+++ b/index.md
@@ -1,12 +1,13 @@
 ---
 title: My Experience as a UT Austin MSDS Student
+layout: home
 ---
 
 This blog serves as a journal for my journey as a Master's of Data Science student at the University of Texas at Austin.
 
 I started this way after I completed a big portion of my degree, but I wanted to document my efforts, results, and resources for others to use as reference.
 
-Read the [semester journey](/semesters/) for term-by-term posts, or browse by [tag](/tags/).
+Browse [by semester](/semesters/) or [by tag](/tags/).
 
 ## My Course Schedule
 

--- a/semesters.md
+++ b/semesters.md
@@ -1,5 +1,5 @@
 ---
-title: Journey
+title: By Semester
 permalink: /semesters/
 ---
 
@@ -8,18 +8,12 @@ Semester-by-semester write-ups from my MSDS program. [Back to home](/).
 <!-- vale off -->
 {% assign semester_posts = site.posts | where_exp: "item", "item.semester_post" | sort: "semester" %}
 
-<ul class="post-list journey-list">
-{% for post in semester_posts %}
-  <li class="post-item semester-card">
-    <p class="badge">Semester {{ post.semester }} · {% include semester-dates.html post=post %}</p>
-    <h3>
-      <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
-    </h3>
-    {% if post.image %}
-    <a href="{{ post.url | relative_url }}"><img class="semester-card-thumb" src="{{ post.image | relative_url }}" alt="" width="120" loading="lazy"></a>
-    {% endif %}
-    <div class="post-excerpt">{{ post.excerpt }}</div>
-  </li>
-{% endfor %}
-</ul>
+<div class="post-list-sortable" data-sort-default="asc" data-sort-default-key="semester" data-sort-storage-key="/semesters/">
+  {% include post-list-sort-controls.html mode=semester %}
+  <ul class="post-list journey-list">
+  {% for post in semester_posts %}
+    {% include post-list-item.html post=post %}
+  {% endfor %}
+  </ul>
+</div>
 <!-- vale on -->

--- a/tags.md
+++ b/tags.md
@@ -1,5 +1,5 @@
 ---
-title: Tags
+title: By Tag
 permalink: /tags/
 ---
 
@@ -12,13 +12,17 @@ Posts grouped by topic.
   {% if tag %}
   <li id="tag-{{ tag | slugify }}">
     <h2>{{ tag }}</h2>
-    <ul>
-      {% for post in site.posts %}
+    {% assign posts_by_date = site.posts | sort: 'date' %}
+    <div class="post-list-sortable" data-sort-default="asc" data-sort-default-key="date" data-sort-storage-key="/tags/{{ tag | slugify }}">
+      {% include post-list-sort-controls.html %}
+      <ul class="post-list tag-post-list">
+      {% for post in posts_by_date %}
         {% if post.tags contains tag %}
-        <li><a href="{{ post.url | relative_url }}">{{ post.title | escape }}</a></li>
+        {% include post-list-item.html post=post %}
         {% endif %}
       {% endfor %}
-    </ul>
+      </ul>
+    </div>
   </li>
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
## Summary

- Fix the course schedule table by rendering a single HTML table from `_data/courses.yml` (no broken GFM rows).
- Restore compact post listings on home, By Semester, and By Tag using `description` teasers instead of full post bodies.
- Default sort to earliest-first (by date on home/tags; by semester on `/semesters/`).
- Add client-side sort controls (oldest/newest on home and tags; by semester/by date on `/semesters/`) with localStorage persistence.
- Rename header nav to **By Semester** and **By Tag**.

## Test plan

- [ ] Home: intro → one course table → Posts list with one-line descriptions
- [ ] Home sort: Oldest first / Newest first toggles work; preference survives refresh
- [ ] Header shows By Semester and By Tag (no Journey)
- [ ] `/semesters/`: semester posts only, compact cards, By semester / By date controls
- [ ] `/tags/`: posts per tag oldest-first by default; sort toggle per tag section
- [ ] Individual post pages unchanged (full content, semester prev/next)