### PR TITLE
Fix tags page rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .venv/
+_site/

--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ show_excerpts: true
 excerpt_separator: "<!--more-->"
 header_pages:
   - semesters.md
-  - tags.md
+  - tags.html
 plugins:
   - jekyll-feed
   - jekyll-seo-tag

--- a/_includes/semester-dates.html
+++ b/_includes/semester-dates.html
@@ -1,11 +1,7 @@
-{% assign post_ref = include.post | default: page %}
-{% assign sem_data = site.data.semesters | where: "number", post_ref.semester | first %}
-{% assign start = sem_data.semester_start %}
-{% assign end = sem_data.semester_end %}
-{% assign start_month = start | date: "%-m" %}
-{% if start_month == "9" %}Sept{% else %}{{ start | date: "%b" }}{% endif %}
-{{ start | date: "%Y" }}
-–
-{% assign end_month = end | date: "%-m" %}
-{% if end_month == "9" %}Sept{% else %}{{ end | date: "%b" }}{% endif %}
-{{ end | date: "%Y" }}
+{%- assign post_ref = include.post | default: page -%}
+{%- assign sem_data = site.data.semesters | where: "number", post_ref.semester | first -%}
+{%- assign start = sem_data.semester_start -%}
+{%- assign end = sem_data.semester_end -%}
+{%- assign start_month = start | date: "%-m" -%}
+{%- if start_month == "9" -%}Sept{%- else -%}{{ start | date: "%b" }}{%- endif %} {{ start | date: "%Y" }} – {% assign end_month = end | date: "%-m" -%}
+{%- if end_month == "9" -%}Sept{%- else -%}{{ end | date: "%b" }}{%- endif %} {{ end | date: "%Y" }}

--- a/_includes/tags-by-topic.html
+++ b/_includes/tags-by-topic.html
@@ -1,10 +1,3 @@
----
-title: By Tag
-permalink: /tags/
----
-
-Posts grouped by topic.
-
 <!-- vale off -->
 {% assign all_tags = site.posts | map: "tags" | flatten | uniq | sort %}
 {% for tag in all_tags %}

--- a/tags.html
+++ b/tags.html
@@ -1,0 +1,8 @@
+---
+layout: page
+title: By Tag
+permalink: /tags/
+---
+
+<p>Posts grouped by topic.</p>
+{% include tags-by-topic.html %}


### PR DESCRIPTION
## Summary
- Fix the By Tag page showing raw HTML/Liquid by moving tag listing logic into `_includes/tags-by-topic.html` and serving it from `tags.html` (bypasses Kramdown mangling mixed Liquid + HTML)
- Add `layout: page` so the tags page keeps the normal site header, nav, and footer
- Render semester date badges inline (`Jan 2026 – Apr 2026`) instead of broken multi-line output
- Gitignore `_site/` from local Jekyll builds

## Test plan
- [ ] Visit `/tags/` and confirm tag headings and post lists render (no visible HTML or `{% ... %}` text)
- [ ] Confirm nav link to By Tag still works
- [ ] Check semester badges on tags and semesters pages show dates on one line
- [ ] Verify page has full site layout (header, footer)