### PR TITLE
Use slug-only post URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ markdown: kramdown
 kramdown:
   input: GFM
   auto_ids: true
-permalink: pretty
+permalink: /:title/
 future: true
 show_excerpts: true
 excerpt_separator: "<!--more-->"


### PR DESCRIPTION
## Summary
- Changes site `permalink` from `pretty` (`/2023/12/31/first-semester/`) to `/:title/` (`/first-semester/`).
- Slugs still come from `_posts/YYYY-MM-DD-<slug>.md` filenames; post `date` front matter is unchanged.
- No `redirect_from` entries — old dated URLs will 404 after deploy.

## Test plan
- [ ] Run `bundle exec jekyll serve` and open a few posts at new paths (e.g. `/first-semester/`, `/bounce-back/`).
- [ ] Confirm home, semester nav, related posts, and tags links use slug-only URLs.
- [ ] Confirm `/semesters/` and `/tags/` still work.
- [ ] Optionally verify an old dated URL returns 404 (expected).